### PR TITLE
Modify worker query to return ids of inserted records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,7 @@ gemspec
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 
+group :test do
+  gem "pg", "< 1.0"
+end
+

--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -19,7 +19,7 @@ module BulkInsert
           worker.save!
         end
       else
-        []
+        worker
       end
     end
 

--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -13,13 +13,11 @@ module BulkInsert
           worker.add_all(values)
           worker.save!
         end
-        nil
       elsif block_given?
         transaction do
           yield worker
           worker.save!
         end
-        nil
       else
         worker
       end

--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -6,7 +6,7 @@ module BulkInsert
   module ClassMethods
     def bulk_insert(*columns, values: nil, set_size:500, ignore: false, update_duplicates: false, return_primary_keys: false)
       columns = default_bulk_columns if columns.empty?
-      worker = BulkInsert::Worker.new(connection, table_name, self.primary_key, columns, set_size, ignore, update_duplicates, return_primary_keys)
+      worker = BulkInsert::Worker.new(connection, table_name, primary_key, columns, set_size, ignore, update_duplicates, return_primary_keys)
 
       if values.present?
         transaction do

--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -4,9 +4,9 @@ module BulkInsert
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def bulk_insert(*columns, values: nil, set_size:500, ignore: false, update_duplicates: false)
+    def bulk_insert(*columns, values: nil, set_size:500, ignore: false, update_duplicates: false, return_primary_keys: false)
       columns = default_bulk_columns if columns.empty?
-      worker = BulkInsert::Worker.new(connection, table_name, columns, set_size, ignore, update_duplicates)
+      worker = BulkInsert::Worker.new(connection, table_name, self.primary_key, columns, set_size, ignore, update_duplicates, return_primary_keys)
 
       if values.present?
         transaction do

--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -19,7 +19,7 @@ module BulkInsert
           worker.save!
         end
       else
-        worker
+        []
       end
     end
 

--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -13,11 +13,13 @@ module BulkInsert
           worker.add_all(values)
           worker.save!
         end
+        nil
       elsif block_given?
         transaction do
           yield worker
           worker.save!
         end
+        nil
       else
         worker
       end

--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -5,7 +5,7 @@ module BulkInsert
     attr_accessor :before_save_callback
     attr_accessor :after_save_callback
     attr_accessor :adapter_name
-    attr_reader :ignore, :update_duplicates, :results
+    attr_reader :ignore, :update_duplicates, :result_sets
 
     def initialize(connection, table_name, column_names, set_size=500, ignore=false, update_duplicates=false)
       @connection = connection
@@ -26,7 +26,7 @@ module BulkInsert
       @before_save_callback = nil
       @after_save_callback = nil
 
-      @results = []
+      @result_sets = []
       @set = []
     end
 
@@ -77,7 +77,7 @@ module BulkInsert
     def save!
       if pending?
         @before_save_callback.(@set) if @before_save_callback
-        @results.concat(execute_query)
+        execute_query
         @after_save_callback.() if @after_save_callback
         @set.clear
       end
@@ -87,9 +87,8 @@ module BulkInsert
 
     def execute_query
       if query = compose_insert_query
-        @connection.execute(query).to_a
-      else
-        []
+        result_set = @connection.execute(query)
+        @result_sets.push(result_set)
       end
     end
 

--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -77,7 +77,7 @@ module BulkInsert
     def save!
       if pending?
         @before_save_callback.(@set) if @before_save_callback
-        @results += execute_query
+        @results.concat(execute_query)
         @after_save_callback.() if @after_save_callback
         @set.clear
       end

--- a/lib/bulk_insert/worker.rb
+++ b/lib/bulk_insert/worker.rb
@@ -89,7 +89,7 @@ module BulkInsert
 
     def execute_query
       if query = compose_insert_query
-        result_set = @connection.execute(query)
+        result_set = @connection.exec_query(query)
         @result_sets.push(result_set) if @return_primary_keys
       end
     end

--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -128,7 +128,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
       %w(greeting age happy created_at updated_at color)
     )
     worker.add greeting: "first"
-    worker.add geeting: "second"
+    worker.add greeting: "second"
     worker.save!
     assert_equal 1, worker.result_sets.count
     assert_equal 2, worker.result_sets.map(&:to_a).flatten.count

--- a/test/bulk_insert/worker_test.rb
+++ b/test/bulk_insert/worker_test.rb
@@ -5,6 +5,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     @insert = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color))
     @now = Time.now
   end
@@ -125,6 +126,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color),
       500,
       false,
@@ -142,6 +144,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color),
       500,
       false,
@@ -165,6 +168,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color),
       500,
       false,
@@ -180,6 +184,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color),
       500,
       false,
@@ -207,6 +212,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     new_worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color)
     )
     assert_instance_of(Array, new_worker.result_sets)
@@ -317,6 +323,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     mysql_worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color),
       500, # batch size
       true) # ignore
@@ -336,6 +343,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     mysql_worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color),
       500, # batch size
       true, # ignore
@@ -354,6 +362,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     mysql_worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color),
       500, # batch size
       true) # ignore
@@ -370,6 +379,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     pgsql_worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color),
       500, # batch size
       true, # ignore
@@ -386,6 +396,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     pgsql_worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color),
       500, # batch size
       true, # ignore
@@ -402,6 +413,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     sqlite_worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color),
       500, # batch size
       true) # ignore
@@ -415,6 +427,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     sqlite_worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color),
       500, # batch size
       true) # ignore
@@ -428,6 +441,7 @@ class BulkInsertWorkerTest < ActiveSupport::TestCase
     mysql_worker = BulkInsert::Worker.new(
       Testing.connection,
       Testing.table_name,
+      'id',
       %w(greeting age happy created_at updated_at color),
       500, # batch size
       false, # ignore

--- a/test/bulk_insert_test.rb
+++ b/test/bulk_insert_test.rb
@@ -29,22 +29,6 @@ class BulkInsertTest < ActiveSupport::TestCase
     end
   end
 
-  test "ids returned in the same order as the records appear in the insert statement" do
-    attributes_for_insertion = (0..99).map { |i| { age: i } }
-    result_set = Testing.bulk_insert values: attributes_for_insertion
-
-    returned_ids = result_set.map {|result| result.fetch("id").to_i }
-    expected_age_for_id_hash = {}
-    returned_ids.map.with_index do |id, age|
-      expected_age_for_id_hash[id] = age
-    end
-
-    new_saved_records = Testing.find(returned_ids)
-    new_saved_records.each do |record|
-      assert_same(expected_age_for_id_hash[record.id], record.age)
-    end
-  end
-
   test "default_bulk_columns should return all columns without id" do
     default_columns = %w(greeting age happy created_at updated_at color)
 

--- a/test/bulk_insert_test.rb
+++ b/test/bulk_insert_test.rb
@@ -20,6 +20,20 @@ class BulkInsertTest < ActiveSupport::TestCase
     end
   end
 
+  test "worker should not have any result sets without option for returning primary keys" do
+    worker = Testing.bulk_insert
+    worker.add greeting: "hello"
+    worker.save!
+    assert_empty worker.result_sets
+  end
+
+  test "with option to return primary keys, worker should have result sets" do
+    worker = Testing.bulk_insert(return_primary_keys: true)
+    worker.add greeting: "yo"
+    worker.save!
+    assert_equal 1, worker.result_sets.count
+  end
+
   test "bulk_insert with array should save the array immediately" do
     assert_difference "Testing.count", 2 do
       Testing.bulk_insert values: [

--- a/test/bulk_insert_test.rb
+++ b/test/bulk_insert_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
 class BulkInsertTest < ActiveSupport::TestCase
-  test "bulk_insert without block should return empty result" do
+  test "bulk_insert without block should return worker" do
     result = Testing.bulk_insert
-    assert_empty result
+    assert_kind_of BulkInsert::Worker, result
   end
 
   test "bulk_insert with block should yield worker" do
@@ -43,14 +43,6 @@ class BulkInsertTest < ActiveSupport::TestCase
     new_saved_records.each do |record|
       assert_same(expected_age_for_id_hash[record.id], record.age)
     end
-  end
-
-  test "returns empty array if called with empty block" do
-    assert_empty(Testing.bulk_insert { |worker| })
-  end
-
-  test "returns empty array if called with empty values" do
-    assert_empty Testing.bulk_insert(values: [])
   end
 
   test "default_bulk_columns should return all columns without id" do

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -1,25 +1,16 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: bulk_insert_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: bulk_insert_test
 
-production:
-  <<: *default
-  database: db/production.sqlite3

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -13,6 +13,9 @@
 
 ActiveRecord::Schema.define(version: 20151028194232) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "testings", force: :cascade do |t|
     t.string   "greeting"
     t.integer  "age"


### PR DESCRIPTION
These changes add a "RETURNING id" clause to the end of a bulk insert query, causing the ids of inserted records to be returned. For example, you could get the returned ids like this:
```
worker = Billings::Progress.bulk_insert
worker.add(params)
worker.save!
worker.result_sets # array of query result sets (one for each call to save!) that contain ids
```

[Here's a link to the docs describing the RETURNING clause](https://www.postgresql.org/docs/9.5/static/sql-insert.html)